### PR TITLE
Add tlog upload and use file writes rather than byte outputs

### DIFF
--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_BINARY: builder
   PROVENANCE_BINARY: provenance
   BUILDER_REPOSITORY: asraa/slsa-on-github
-  BUILDER_REF: main
+  BUILDER_REF: prov-write
 
 ###################################################################
 #                                                                 #

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_BINARY: builder
   PROVENANCE_BINARY: provenance
   BUILDER_REPOSITORY: asraa/slsa-on-github
-  BUILDER_REF: main
+  BUILDER_REF: prov-write
 
 ###################################################################
 #                                                                 #
@@ -356,17 +356,15 @@ jobs:
 
           echo "provenance generator is $PROVENANCE_BINARY"
 
-          # Create provenance
+          # Create and sign provenance
+          # This sets signed-provenance-name to the name of the signed DSSE envelope.
           DIGEST="$UNTRUSTED_BINARY_HASH" ./"$PROVENANCE_BINARY"
-
-          # Sign provenance
-          UNSIGNED_PROVENANCE="$UNTRUSTED_BINARY_NAME.intoto" ./"$PROVENANCE_BINARY"
 
       - name: Upload the signed provenance
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
-          name: "${{ needs.build-dry.outputs.go-binary-name }}.intoto.sig"
-          path: "${{ needs.build-dry.outputs.go-binary-name }}.intoto.sig"
+          name: "${{ steps.sign-prov.outputs.signed-provenance-name }}"
+          path: "${{ steps.sign-prov.outputs.signed-provenance-name }}"
           if-no-files-found: error
           retention-days: 5
 

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -270,6 +270,9 @@ jobs:
 
           echo "::set-output name=go-binary-sha256::$DIGEST"
 
+          # Create unsigned provenance
+          DIGEST="$DIGEST" ./"$PROVENANCE_BINARY"
+
       - name: Upload the artifact
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
@@ -357,11 +360,10 @@ jobs:
           echo "provenance generator is $PROVENANCE_BINARY"
 
           # Create provenance
-          DIGEST="$UNTRUSTED_BINARY_HASH" ./"$PROVENANCE_BINARY" > "$UNTRUSTED_BINARY_NAME.intoto"
+          DIGEST="$UNTRUSTED_BINARY_HASH" ./"$PROVENANCE_BINARY"
 
           # Sign provenance
-          UNSIGNED_PROVENANCE="$UNTRUSTED_BINARY_NAME.intoto" ./"$PROVENANCE_BINARY" > "$UNTRUSTED_BINARY_NAME.signed.intoto"
-          echo "::set-output name=signed-provenance-name::$UNTRUSTED_BINARY_NAME.signed.intoto"
+          UNSIGNED_PROVENANCE="$UNTRUSTED_BINARY_NAME.intoto" ./"$PROVENANCE_BINARY"
 
       - name: Upload the provenance
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -362,18 +362,11 @@ jobs:
           # Sign provenance
           UNSIGNED_PROVENANCE="$UNTRUSTED_BINARY_NAME.intoto" ./"$PROVENANCE_BINARY"
 
-      - name: Upload the provenance
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
-        with:
-          name: "${{ needs.build-dry.outputs.go-binary-name }}.intoto"
-          path: "${{ needs.build-dry.outputs.go-binary-name }}.intoto"
-          if-no-files-found: error
-          retention-days: 5
-
       - name: Upload the signed provenance
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
-          name: ${{ steps.sign-prov.outputs.signed-provenance-name }}
-          path: ${{ steps.sign-prov.outputs.signed-provenance-name }}
+          name: "${{ needs.build-dry.outputs.go-binary-name }}.intoto.sig"
+          path: "${{ needs.build-dry.outputs.go-binary-name }}.intoto.sig"
           if-no-files-found: error
           retention-days: 5
+

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -310,8 +310,13 @@ jobs:
       - name: Upload the generated binary
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
+<<<<<<< HEAD
           name: "${{ needs.build-dry.outputs.go-binary-name }}"
           path: "${{ needs.build-dry.outputs.go-binary-name }}"
+=======
+          name: "${{ steps.sha256-gen.outputs.provenance-name }}"
+          path: "${{ steps.sha256-gen.outputs.provenance-name }}"
+>>>>>>> 3c4ab0d (update)
           if-no-files-found: error
           retention-days: 5
 

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -373,7 +373,7 @@ jobs:
       - name: Upload the signed provenance
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
-          name: "${{ needs.build-dry.outputs.go-binary-name }}.signed.intoto"
-          path: "${{ needs.build-dry.outputs.go-binary-name }}.signed.intoto"
+          name: "${{ steps.sign-prov.outputs.signed-provenance-name }}"
+          path: "${{ steps.sign-prov.outputs.signed-provenance-name }}"
           if-no-files-found: error
           retention-days: 5

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_BINARY: builder
   PROVENANCE_BINARY: provenance
   BUILDER_REPOSITORY: asraa/slsa-on-github
-  BUILDER_REF: main
+  BUILDER_REF: prov-write
 
 ###################################################################
 #                                                                 #
@@ -310,13 +310,8 @@ jobs:
       - name: Upload the generated binary
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
-<<<<<<< HEAD
           name: "${{ needs.build-dry.outputs.go-binary-name }}"
           path: "${{ needs.build-dry.outputs.go-binary-name }}"
-=======
-          name: "${{ steps.sha256-gen.outputs.provenance-name }}"
-          path: "${{ steps.sha256-gen.outputs.provenance-name }}"
->>>>>>> 3c4ab0d (update)
           if-no-files-found: error
           retention-days: 5
 

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -373,7 +373,7 @@ jobs:
       - name: Upload the signed provenance
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
-          name: "${{ steps.sign-prov.outputs.signed-provenance-name }}"
-          path: "${{ steps.sign-prov.outputs.signed-provenance-name }}"
+          name: ${{ steps.sign-prov.outputs.signed-provenance-name }}
+          path: ${{ steps.sign-prov.outputs.signed-provenance-name }}
           if-no-files-found: error
           retention-days: 5

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -270,9 +270,6 @@ jobs:
 
           echo "::set-output name=go-binary-sha256::$DIGEST"
 
-          # Create unsigned provenance
-          DIGEST="$DIGEST" ./"$PROVENANCE_BINARY"
-
       - name: Upload the artifact
         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:

--- a/.github/workflows/slsa-builder-go.yml
+++ b/.github/workflows/slsa-builder-go.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_BINARY: builder
   PROVENANCE_BINARY: provenance
   BUILDER_REPOSITORY: asraa/slsa-on-github
-  BUILDER_REF: prov-write
+  BUILDER_REF: main
 
 ###################################################################
 #                                                                 #

--- a/slsa-provenance/go.mod
+++ b/slsa-provenance/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.20.1 // indirect
@@ -171,6 +172,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.20.0 // indirect
+	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/slsa-provenance/go.sum
+++ b/slsa-provenance/go.sum
@@ -685,6 +685,7 @@ github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYis
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -164,7 +164,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if _, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, signedAtt, k.Cert); err != nil {
+	if _, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, signedAtt, []byte(string(k.Cert))); err != nil {
 		panic(err)
 	}
 

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -164,7 +164,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if _, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, signedAtt, attBytes); err != nil {
+	if _, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, signedAtt, k.Cert); err != nil {
 		panic(err)
 	}
 

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -150,8 +150,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf(string(k.Cert))
-	fmt.Printf(string([]byte(string(k.Cert))))
+	fmt.Printf("%d", len(string(k.Cert)))
+	fmt.Printf("%d", len(string([]byte(string(k.Cert)))))
 
 	wrappedSigner := dsse.WrapSigner(k, intoto.PayloadType)
 

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -16,6 +16,8 @@ import (
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	dsselib "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
+	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
+	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/providers"
 	_ "github.com/sigstore/cosign/pkg/providers/all"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
@@ -25,6 +27,7 @@ const (
 	defaultFulcioAddr   = "https://fulcio.sigstore.dev"
 	defaultOIDCIssuer   = "https://oauth2.sigstore.dev/auth"
 	defaultOIDCClientID = "sigstore"
+	defaultRekorAddr    = "https://rekor.sigstore.dev"
 )
 
 type GitHubContext struct {
@@ -153,6 +156,15 @@ func main() {
 
 	signedAtt, err := wrappedSigner.SignMessage(bytes.NewReader(attBytes))
 	if err != nil {
+		panic(err)
+	}
+
+	// Upload to tlog
+	rekorClient, err := rekor.NewClient(defaultRekorAddr)
+	if err != nil {
+		panic(err)
+	}
+	if _, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, signedAtt, attBytes); err != nil {
 		panic(err)
 	}
 

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -183,5 +183,5 @@ func main() {
 	if err := ioutil.WriteFile(filename, payload, 0600); err != nil {
 		panic(err)
 	}
-	fmt.Printf(`::set-output name=signed-provenance-name::%s`, filename)
+	fmt.Printf(`::set-output name=signed-provenance-name::%s\n`, filename)
 }

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -119,7 +119,6 @@ func main() {
 		if err := ioutil.WriteFile("provenance.intoto", attBytes, 0600); err != nil {
 			panic(err)
 		}
-		fmt.Printf("wrote file provenance.intoto")
 		fmt.Printf(`::set-output name=provenance-name::%s`, "provenance.intoto")
 		return
 	}

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	cjson "github.com/docker/go/canonical/json"
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
@@ -42,95 +43,85 @@ type GitHubContext struct {
 }
 
 func main() {
-	provenance, ok := os.LookupEnv("UNSIGNED_PROVENANCE")
 	// Generate the provenance
 	// TODO: Refactor with flags library.
+	digest, ok := os.LookupEnv("DIGEST")
 	if !ok {
-		digest, ok := os.LookupEnv("DIGEST")
-		if !ok {
-			panic(errors.New("Environment variable DIGEST not present"))
-		}
-
-		binary, ok := os.LookupEnv("UNTRUSTED_BINARY_NAME")
-		if !ok {
-			panic(errors.New("Environment variable UNTRUSTED_BINARY_NAME not present"))
-		}
-
-		githubContext, ok := os.LookupEnv("GITHUB_CONTEXT")
-		if !ok {
-			panic(errors.New("Environment variable GITHUB_CONTEXT not present"))
-		}
-
-		gh := &GitHubContext{}
-		if err := json.Unmarshal([]byte(githubContext), gh); err != nil {
-			panic(err)
-		}
-
-		if _, err := hex.DecodeString(digest); err != nil || len(digest) != 64 {
-			log.Fatal(fmt.Errorf("sha256 digest is not valid: %s", digest))
-		}
-
-		att := intoto.ProvenanceStatement{
-			StatementHeader: intoto.StatementHeader{
-				Type:          intoto.StatementInTotoV01,
-				PredicateType: slsa.PredicateSLSAProvenance,
-				Subject: []intoto.Subject{
-					{
-						Name: binary,
-						Digest: slsa.DigestSet{
-							"sha256": digest,
-						},
-					},
-				},
-			},
-			Predicate: slsa.ProvenancePredicate{
-				BuildType: "https://github.com/Attestations/GitHubActionsWorkflow@v1",
-				Builder: slsa.ProvenanceBuilder{
-					ID: "https://github.com/Attestations/GitHubHostedActions@v1",
-				},
-				Invocation: slsa.ProvenanceInvocation{
-					ConfigSource: slsa.ConfigSource{
-						EntryPoint: gh.Workflow,
-						URI:        fmt.Sprintf("git+%s.git", gh.Repository),
-						Digest: slsa.DigestSet{
-							"SHA1": gh.SHA,
-						},
-					},
-					// Add event inputs
-					Environment: map[string]interface{}{
-						"arch": "amd64", // TODO: Does GitHub run actually expose this?
-						"env": map[string]string{
-							"GITHUB_RUN_NUMBER": gh.RunNumber,
-							"GITHUB_RUN_ID":     gh.RunId,
-							"GITHUB_EVENT_NAME": gh.EventName,
-						},
-					},
-				},
-				Materials: []slsa.ProvenanceMaterial{{
-					URI: fmt.Sprintf("git+%s.git", gh.Repository),
-					Digest: slsa.DigestSet{
-						"SHA1": gh.SHA,
-					}},
-				},
-			},
-		}
-
-		attBytes, err := cjson.MarshalCanonical(att)
-		if err != nil {
-			panic(err)
-		}
-
-		filename := fmt.Sprintf("%s.intoto", binary)
-		if err := ioutil.WriteFile(filename, attBytes, 0600); err != nil {
-			panic(err)
-		}
-		fmt.Printf(`::set-output name=provenance-name::%s`, filename)
-		return
+		panic(errors.New("Environment variable DIGEST not present"))
 	}
 
-	attBytes, err := ioutil.ReadFile(provenance)
+	binary, ok := os.LookupEnv("UNTRUSTED_BINARY_NAME")
+	if !ok {
+		panic(errors.New("Environment variable UNTRUSTED_BINARY_NAME not present"))
+	}
+
+	// This binary filename is verified in the builder's dry-run step,
+	// but we verify it only contains alphanumeric characters again as well.
+	if err := verifyProvenanceName(binary); err != nil {
+		panic(err)
+	}
+
+	githubContext, ok := os.LookupEnv("GITHUB_CONTEXT")
+	if !ok {
+		panic(errors.New("Environment variable GITHUB_CONTEXT not present"))
+	}
+
+	gh := &GitHubContext{}
+	if err := json.Unmarshal([]byte(githubContext), gh); err != nil {
+		panic(err)
+	}
+
+	if _, err := hex.DecodeString(digest); err != nil || len(digest) != 64 {
+		log.Fatal(fmt.Errorf("sha256 digest is not valid: %s", digest))
+	}
+
+	att := intoto.ProvenanceStatement{
+		StatementHeader: intoto.StatementHeader{
+			Type:          intoto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject: []intoto.Subject{
+				{
+					Name: binary,
+					Digest: slsa.DigestSet{
+						"sha256": digest,
+					},
+				},
+			},
+		},
+		Predicate: slsa.ProvenancePredicate{
+			BuildType: "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+			Builder: slsa.ProvenanceBuilder{
+				ID: "https://github.com/Attestations/GitHubHostedActions@v1",
+			},
+			Invocation: slsa.ProvenanceInvocation{
+				ConfigSource: slsa.ConfigSource{
+					EntryPoint: gh.Workflow,
+					URI:        fmt.Sprintf("git+%s.git", gh.Repository),
+					Digest: slsa.DigestSet{
+						"SHA1": gh.SHA,
+					},
+				},
+				// Add event inputs
+				Environment: map[string]interface{}{
+					"arch": "amd64", // TODO: Does GitHub run actually expose this?
+					"env": map[string]string{
+						"GITHUB_RUN_NUMBER": gh.RunNumber,
+						"GITHUB_RUN_ID":     gh.RunId,
+						"GITHUB_EVENT_NAME": gh.EventName,
+					},
+				},
+			},
+			Materials: []slsa.ProvenanceMaterial{{
+				URI: fmt.Sprintf("git+%s.git", gh.Repository),
+				Digest: slsa.DigestSet{
+					"SHA1": gh.SHA,
+				}},
+			},
+		},
+	}
+
+	attBytes, err := cjson.MarshalCanonical(att)
 	if err != nil {
-		attBytes = []byte(provenance)
 		panic(err)
 	}
 
@@ -179,9 +170,25 @@ func main() {
 		panic(err)
 	}
 
-	filename := fmt.Sprintf("%s.sig", provenance)
+	filename := fmt.Sprintf("%s.intoto.sig", binary)
 	if err := ioutil.WriteFile(filename, payload, 0600); err != nil {
 		panic(err)
 	}
 	fmt.Printf(`::set-output name=signed-provenance-name::%s\n`, filename)
+}
+
+func verifyProvenanceName(name string) error {
+	const alpha = "abcdefghijklmnopqrstuvwxyz1234567890-_"
+
+	if name == "" {
+		return errors.New("empty provenance name")
+	}
+
+	for _, char := range name {
+		if !strings.Contains(alpha, strings.ToLower(string(char))) {
+			return fmt.Errorf("invalid filename: found character '%c' in %s", char, name)
+		}
+	}
+
+	return nil
 }

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -165,9 +165,11 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if _, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, signedAtt, []byte(string(k.Cert))); err != nil {
+	model, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, signedAtt, []byte(string(k.Cert)))
+	if err != nil {
 		panic(err)
 	}
+	fmt.Printf("log index %d", model.LogIndex)
 
 	envelope := &dsselib.Envelope{}
 	if err = json.Unmarshal(signedAtt, envelope); err != nil {

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -151,6 +151,7 @@ func main() {
 		panic(err)
 	}
 	fmt.Printf(string(k.Cert))
+	fmt.Printf(string([]byte(string(k.Cert))))
 
 	wrappedSigner := dsse.WrapSigner(k, intoto.PayloadType)
 

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -119,6 +119,7 @@ func main() {
 		if err := ioutil.WriteFile("provenance.intoto", attBytes, 0600); err != nil {
 			panic(err)
 		}
+		fmt.Printf("wrote file provenance.intoto")
 		fmt.Printf(`::set-output name=provenance-name::%s`, "provenance.intoto")
 		return
 	}

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -150,8 +150,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("%d", len(string(k.Cert)))
-	fmt.Printf("%d", len(string([]byte(string(k.Cert)))))
+	fmt.Printf("%d\n", len(string([]byte(string(k.Cert)))))
 
 	wrappedSigner := dsse.WrapSigner(k, intoto.PayloadType)
 
@@ -169,7 +168,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Printf("log index %d", model.LogIndex)
+	fmt.Printf("log index %d\n", *model.LogIndex)
 
 	envelope := &dsselib.Envelope{}
 	if err = json.Unmarshal(signedAtt, envelope); err != nil {

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -174,7 +174,7 @@ func main() {
 	if err := ioutil.WriteFile(filename, payload, 0600); err != nil {
 		panic(err)
 	}
-	fmt.Printf(`::set-output name=signed-provenance-name::%s\n`, filename)
+	fmt.Printf("::set-output name=signed-provenance-name::%s\n", filename)
 }
 
 func verifyProvenanceName(name string) error {

--- a/slsa-provenance/main.go
+++ b/slsa-provenance/main.go
@@ -116,12 +116,13 @@ func main() {
 			panic(err)
 		}
 
-		fmt.Printf(string(attBytes))
-		fmt.Printf(`::set-output name=provenance::%s`, string(attBytes))
+		if err := ioutil.WriteFile("provenance.intoto", attBytes, 0600); err != nil {
+			panic(err)
+		}
+		fmt.Printf(`::set-output name=provenance-name::%s`, "provenance.intoto")
 		return
 	}
 
-	fmt.Printf(provenance)
 	attBytes, err := ioutil.ReadFile(provenance)
 	if err != nil {
 		attBytes = []byte(provenance)
@@ -146,6 +147,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	fmt.Printf(string(k.Cert))
+
 	wrappedSigner := dsse.WrapSigner(k, intoto.PayloadType)
 
 	signedAtt, err := wrappedSigner.SignMessage(bytes.NewReader(attBytes))
@@ -163,5 +166,8 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Printf(string(payload))
+	if err := ioutil.WriteFile("provenance.signed.intoto", payload, 0600); err != nil {
+		panic(err)
+	}
+	fmt.Printf(`::set-output name=signed-provenance-name::%s`, "provenance.signed.intoto")
 }


### PR DESCRIPTION
Signing with fulcio signers didn't auto-upload to the tlog, so adding that.
Also writing the file in the script, rather than output bytes and catting that to a file.

The tlog entry can be searched with rekor by the binary sha256sum

Thoughts:
* How do we distinguish between the provenance created in this action vs one created & uploaded (to overwrite) by a concurrent job in the same workflow run? The "malicious" provenance would still need to reference the same binary sha256sum. But we don't have "job" information in our provenance. Maybe we do. We can access the job context and add it to the provenance https://docs.github.com/en/actions/learn-github-actions/contexts#job-context

EDIT: Laurent's pointed out that w/ workflow verification no other job should have access to the id-token to use OIDC signing. So we can trust that only our job had the access to create signed provenance with a Fulcio issued cert.